### PR TITLE
Implemented Namespacing Throughout Library.

### DIFF
--- a/entities/Check/HpsCheck.php
+++ b/entities/Check/HpsCheck.php
@@ -1,4 +1,7 @@
 <?php
+
+namespace Heartland\Entities\Check;
+
  class HpsCheck {
      public $routingNumber  = null;
      public $accountNumber  = null;

--- a/entities/Check/HpsCheckHolder.php
+++ b/entities/Check/HpsCheckHolder.php
@@ -1,6 +1,8 @@
 <?php
 
-class HpsCheckHolder extends HpsConsumer {
+namespace Heartland\Entities\Check;
+
+class HpsCheckHolder extends \Heartland\Entities\HpsConsumer {
     public  $checkName      = null,
             $dlState        = null,
             $dlNumber       = null,

--- a/entities/Check/HpsCheckResponse.php
+++ b/entities/Check/HpsCheckResponse.php
@@ -1,6 +1,8 @@
 <?php
 
-class HpsCheckResponse extends HpsTransaction{
+namespace Heartland\Entities\Check;
+
+class HpsCheckResponse extends \Heartland\Entities\HpsTransaction{
     public  $authorizationCode  = null,
             $customerId         = null,
             $details            = null;

--- a/entities/Check/HpsCheckResponseDetails.php
+++ b/entities/Check/HpsCheckResponseDetails.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Heartland\Entities\Check;
+
 class HpsCheckResponseDetails {
     public $messageType = null;
     public $code = null;

--- a/entities/HpsAccountVerify.php
+++ b/entities/HpsAccountVerify.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Heartland\Entities;
+
 class HpsAccountVerify extends HpsAuthorization{
     public function __construct($header){
         parent::__construct($header);

--- a/entities/HpsAddress.php
+++ b/entities/HpsAddress.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Heartland\Entities;
+
 class HpsAddress {
     public  $address    = null,
             $city       = null,

--- a/entities/HpsAuthorization.php
+++ b/entities/HpsAuthorization.php
@@ -1,5 +1,6 @@
 <?php
 
+namespace Heartland\Entities;
 
 class HpsAuthorization extends HpsTransaction {
     public  $avsResultCode      = null,

--- a/entities/HpsBatch.php
+++ b/entities/HpsBatch.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Heartland\Entities;
+
 class HpsBatch {
     public  $id                 = null,
             $transactionCount   = null,

--- a/entities/HpsCardHolder.php
+++ b/entities/HpsCardHolder.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Heartland\Entities;
+
 class HpsCardHolder extends HpsConsumer {
 
 } 

--- a/entities/HpsCharge.php
+++ b/entities/HpsCharge.php
@@ -1,4 +1,6 @@
 <?php
 
+namespace Heartland\Entities;
+
 class HpsCharge extends HpsAuthorization{
 } 

--- a/entities/HpsChargeExceptions.php
+++ b/entities/HpsChargeExceptions.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Heartland\Entities;
+
 class HpsChargeExceptions {
     public  $cardException  = null,
             $hpsException   = null;

--- a/entities/HpsConsumer.php
+++ b/entities/HpsConsumer.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Heartland\Entities;
+
 class HpsConsumer {
     public  $firstName      = null,
             $lastName       = null,

--- a/entities/HpsCreditCard.php
+++ b/entities/HpsCreditCard.php
@@ -1,5 +1,6 @@
 <?php
 
+namespace Heartland\Entities;
 
 class HpsCreditCard {
     public  $number     = null,

--- a/entities/HpsItemChoiceTypePosResponseVer10Transaction.php
+++ b/entities/HpsItemChoiceTypePosResponseVer10Transaction.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Heartland\Entities;
+
 class HpsItemChoiceTypePosResponseVer10Transaction{
     static public $AddAttachment = "AddAttachment";
     static public $Authenticate = "Authenticate";

--- a/entities/HpsRefund.php
+++ b/entities/HpsRefund.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Heartland\Entities;
+
 class HpsRefund extends HpsTransaction{
     public function __construct($header){
         parent::__construct($header);

--- a/entities/HpsReportTransactionDetails.php
+++ b/entities/HpsReportTransactionDetails.php
@@ -1,5 +1,8 @@
 <?php
 
+namespace Heartland\Entities;
+
+use Heartland\Infrastructure\HpsExceptionMapper;
 
 class HpsReportTransactionDetails extends HpsAuthorization {
     public  $originalTransactionId  = null,

--- a/entities/HpsReportTransactionSummary.php
+++ b/entities/HpsReportTransactionSummary.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace Heartland\Entities;
+
+use Heartland\Infrastructure\HpsExceptionMapper;
+
 class HpsReportTransactionSummary extends HpsTransaction{
     public  $amount                 = null,
             $originalTransactionId  = null,

--- a/entities/HpsReversal.php
+++ b/entities/HpsReversal.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Heartland\Entities;
+
 class HpsReversal extends HpsTransaction{
     public  $avsResultCode  = null,
             $avsResultText  = null,

--- a/entities/HpsTokenData.php
+++ b/entities/HpsTokenData.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Heartland\Entities;
+
 class HpsTokenData {
     public  $tokenValue         = null,
             $responseCode       = null,

--- a/entities/HpsTransaction.php
+++ b/entities/HpsTransaction.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Heartland\Entities;
+
 class HpsTransaction {
     public  $transactionHeader  = null,
             $transactionId      = null,

--- a/entities/HpsTransactionDetails.php
+++ b/entities/HpsTransactionDetails.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Heartland\Entities;
+
 class HpsTransactionDetails {
     public  $memo                   = null,
             $invoiceNumber          = null,

--- a/entities/HpsTransactionHeader.php
+++ b/entities/HpsTransactionHeader.php
@@ -1,6 +1,8 @@
 <?php
 
 
+namespace Heartland\Entities;
+
 class HpsTransactionHeader {
     public  $gatewayResponseCode    = null,
             $gatewayResponseMessage = null,

--- a/entities/HpsTransactionType.php
+++ b/entities/HpsTransactionType.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Heartland\Entities;
+
 class HpsTransactionType {
     static public $AUTHORIZE = 0;
     static public $CAPTURE = 1;

--- a/entities/HpsVoid.php
+++ b/entities/HpsVoid.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Heartland\Entities;
+
 class HpsVoid extends HpsTransaction{
     public function __construct($header){
         parent::__construct($header);

--- a/infrastructure/ApiConnectionException.php
+++ b/infrastructure/ApiConnectionException.php
@@ -1,4 +1,7 @@
 <?php
+
+namespace Heartland\Infrastructure;
+
 class ApiConnectionException extends HpsException{
 
 }

--- a/infrastructure/AuthenticationException.php
+++ b/infrastructure/AuthenticationException.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Heartland\Infrastructure;
+
 class AuthenticationException extends HpsException{
 
     public function __construct($message){

--- a/infrastructure/CardException.php
+++ b/infrastructure/CardException.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Heartland\Infrastructure;
+
 class CardException extends HpsException{
     public  $TransactionId = null;
     public  $ResultText = null;

--- a/infrastructure/HpsCheckException.php
+++ b/infrastructure/HpsCheckException.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Heartland\Infrastructure;
+
 class HpsCheckException extends HpsException{
     public $transactionId = null;
     public $details = null;

--- a/infrastructure/HpsConfiguration.php
+++ b/infrastructure/HpsConfiguration.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Heartland\Infrastructure;
+
 class HpsConfiguration {
     public  $secretApiKey       = null,
             $licenseId          = null,

--- a/infrastructure/HpsException.php
+++ b/infrastructure/HpsException.php
@@ -1,4 +1,9 @@
 <?php
+
+namespace Heartland\Infrastructure;
+
+use Exception;
+
 class HpsException extends Exception{
     public  $code           = null,
             $innerException = null,

--- a/infrastructure/HpsExceptionMapper.php
+++ b/infrastructure/HpsExceptionMapper.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Heartland\Infrastructure;
+
 class HpsExceptionMapper{
 
     private static function _getExceptions(){
@@ -46,7 +48,7 @@ class HpsExceptionMapper{
 
     public static function map_sdk_exception($error_code, $inner_exception = null){
         $mapping = self::exception_for_category_and_code('sdk', $error_code);
-        $sdk_codes = get_class_vars('HpsSdkCodes');
+        $sdk_codes = get_class_vars('\Heartland\Infrastructure\HpsSdkCodes');
         foreach($sdk_codes as $code_name=>$code_value){
             if($code_value == $error_code){
                 $sdk_code_name = $code_name;

--- a/infrastructure/HpsSdkCodes.php
+++ b/infrastructure/HpsSdkCodes.php
@@ -1,4 +1,7 @@
 <?php
+
+namespace Heartland\Infrastructure;
+
 class HpsSdkCodes {
     public static   $invalidTransactionId               = "0",
                     $invalidGatewayUrl                  = "1",

--- a/infrastructure/InvalidRequestException.php
+++ b/infrastructure/InvalidRequestException.php
@@ -1,4 +1,7 @@
 <?php
+
+namespace Heartland\Infrastructure;
+
 class InvalidRequestException extends HpsException{
     public $param = null;
 

--- a/infrastructure/Validation.php
+++ b/infrastructure/Validation.php
@@ -1,5 +1,10 @@
 <?php
 
+namespace Heartland\Infrastructure;
+
+use Heartland\Infrastructure\HpsSdkCodes;
+use Heartland\Infrastructure\HpsExceptionMapper;
+
 class Validation {
     static private $_defaultAllowedCurrencies = array('usd');
 

--- a/services/HpsBatchService.php
+++ b/services/HpsBatchService.php
@@ -1,5 +1,11 @@
 <?php
 
+namespace Heartland\Services;
+
+use DOMDocument;
+use Heartland\Infrastructure\HpsExceptionMapper;
+use Heartland\Entities\HpsBatch;
+
 class HpsBatchService extends HpsService{
     public function closeBatch(){
         $xml = new DOMDocument();

--- a/services/HpsChargeService.php
+++ b/services/HpsChargeService.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Heartland\Services;
+
 class HpsChargeService extends HpsCreditService {
     function __construct(HpsServicesConfig $config=null){
         error_log('HpsChargeService is Deprecated and will soon be removed.', E_USER_DEPRECATED);

--- a/services/HpsCheckService.php
+++ b/services/HpsCheckService.php
@@ -1,5 +1,14 @@
 <?php
 
+namespace Heartland\Services;
+
+use DOMDocument;
+use Heartland\Entities\Check\HpsCheck;
+use Heartland\Infrastructure\Validation;
+use Heartland\Infrastructure\HpsException;
+use Heartland\Entities\Check\HpsCheckResponse;
+use Heartland\Infrastructure\HpsCheckException;
+
 class HpsCheckService extends HpsService {
 
     /**

--- a/services/HpsCreditService.php
+++ b/services/HpsCreditService.php
@@ -1,5 +1,23 @@
 <?php
 
+namespace Heartland\Services;
+
+use DateTime;
+use DOMDocument;
+use Heartland\Entities\HpsCreditCard;
+use Heartland\Infrastructure\Validation;
+use Heartland\Infrastructure\HpsExceptionMapper;
+use Heartland\Infrastructure\HpsSdkCodes;
+use Heartland\Entities\HpsCardHolder;
+use Heartland\Entities\HpsReportTransactionDetails;
+use Heartland\Entities\HpsReportTransactionSummary;
+use Heartland\Entities\HpsCharge;
+use Heartland\Entities\HpsAccountVerify;
+use Heartland\Entities\HpsAuthorization;
+use Heartland\Entities\HpsRefund;
+use Heartland\Entities\HpsReversal;
+use Heartland\Entities\HpsVoid;
+
 class HpsCreditService extends HpsService{
 
     public function authorize($amount, $currency, $cardOrToken, $cardHolder=null, $requestMultiUseToken=false, $details=null, $txnDescriptor=null){

--- a/services/HpsService.php
+++ b/services/HpsService.php
@@ -1,5 +1,11 @@
 <?php
 
+namespace Heartland\Services;
+
+use DOMDocument;
+use Heartland\Infrastructure\HpsExceptionMapper;
+use Heartland\Infrastructure\HpsSdkCodes;
+
 class HpsService {
     public $config = null;
     protected $_amount = null;

--- a/services/HpsServicesConfig.php
+++ b/services/HpsServicesConfig.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Heartland\Services;
+
 class HpsServicesConfig {
     public $credentialToken = null,
            $securityApiKey  = null,

--- a/services/HpsTokenService.php
+++ b/services/HpsTokenService.php
@@ -1,4 +1,10 @@
 <?php
+
+namespace Heartland\Services;
+
+use Heartland\Entities\HpsCreditCard;
+use Heartland\Infrastructure\HpsException;
+
 // This should only be used for testing tokens.
 
 class HpsTokenService {

--- a/tests/AmexTest.php
+++ b/tests/AmexTest.php
@@ -1,5 +1,8 @@
 <?php
 
+use Heartland\Infrastructure\CardException;
+use Heartland\Services\HpsCreditService;
+
 require_once("setup.php"); 
 
 class AmexTest extends PHPUnit_Framework_TestCase

--- a/tests/CertificationTests/CheckCertificationTests.php
+++ b/tests/CertificationTests/CheckCertificationTests.php
@@ -2,6 +2,8 @@
 
 require_once(dirname(__FILE__).'/../setup.php');
 
+use Heartland\Services\HpsCheckService;
+
 class CheckCertificationTests extends PHPUnit_Framework_TestCase{
 
     public function testACHDebitConsumer1(){

--- a/tests/CertificationTests/CreditCertificationTest.php
+++ b/tests/CertificationTests/CreditCertificationTest.php
@@ -1,6 +1,9 @@
 <?php
 require_once(dirname(__FILE__).'/../setup.php');
 
+use Heartland\Services\HpsBatchService;
+use Heartland\Services\HpsCreditService;
+
 class CreditCertificationTests extends PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/CheckTest.php
+++ b/tests/CheckTest.php
@@ -1,5 +1,8 @@
 <?php
 
+use Heartland\Services\HpsCheckService;
+use Heartland\Infrastructure\HpsCheckException;
+
 require_once("setup.php");
 
 class CheckTests extends PHPUnit_Framework_TestCase{

--- a/tests/DiscoverTest.php
+++ b/tests/DiscoverTest.php
@@ -1,5 +1,8 @@
 <?php
 
+use Heartland\Infrastructure\CardException;
+use Heartland\Services\HpsCreditService;
+
 require_once("setup.php");
 
 class DiscoverTest extends PHPUnit_Framework_TestCase

--- a/tests/GeneralTest.php
+++ b/tests/GeneralTest.php
@@ -1,5 +1,9 @@
 <?php
 
+use Heartland\Infrastructure\CardException;
+use Heartland\Infrastructure\InvalidRequestException;
+use Heartland\Services\HpsCreditService;
+
 require_once("setup.php");
 
 class GeneralTests extends PHPUnit_Framework_TestCase

--- a/tests/MasterCardTest.php
+++ b/tests/MasterCardTest.php
@@ -1,5 +1,8 @@
 <?php
 
+use Heartland\Infrastructure\CardException;
+use Heartland\Services\HpsCreditService;
+
 require_once("setup.php");
 
 class MasterCardTests extends PHPUnit_Framework_TestCase

--- a/tests/TestData/TestCardHolder.php
+++ b/tests/TestData/TestCardHolder.php
@@ -1,5 +1,8 @@
 ﻿<?php
 
+use Heartland\Entities\HpsCardHolder;
+use Heartland\Entities\HpsAddress;
+
 class TestCardHolder
 {
 

--- a/tests/TestData/TestCheck.php
+++ b/tests/TestData/TestCheck.php
@@ -1,5 +1,9 @@
 <?php
 
+use Heartland\Entities\HpsAddress;
+use Heartland\Entities\Check\HpsCheckHolder;
+use Heartland\Entities\Check\HpsCheck;
+
 class TestCheck {
     static public function approve(){
         $check = new HpsCheck();

--- a/tests/TestData/TestCreditCard.php
+++ b/tests/TestData/TestCreditCard.php
@@ -1,5 +1,7 @@
 <?php
 
+use Heartland\Entities\HpsCreditCard;
+
 class TestCreditCard
 {
     static public function validVisaCreditCard(){

--- a/tests/TestData/TestServicesConfig.php
+++ b/tests/TestData/TestServicesConfig.php
@@ -1,5 +1,7 @@
 <?php
 
+use Heartland\Services\HpsServicesConfig;
+
 class TestServicesConfig
 {
     private $uatServiceUri = "https://posgateway.cert.secureexchange.net/Hps.Exchange.PosGateway/PosGatewayService.asmx?wsdl";

--- a/tests/TokenServiceTest.php
+++ b/tests/TokenServiceTest.php
@@ -1,5 +1,11 @@
 <?php
 
+use Heartland\Services\HpsCreditService;
+use Heartland\Services\HpsTokenService;
+use Heartland\Services\HpsChargeService;
+use Heartland\Entities\HpsTokenData;
+use Heartland\Infrastructure\HpsException;
+
 require_once("setup.php");
 
 class TokenServiceTests extends PHPUnit_Framework_TestCase{

--- a/tests/VisaTest.php
+++ b/tests/VisaTest.php
@@ -1,5 +1,8 @@
 <?php
 
+use Heartland\Infrastructure\CardException;
+use Heartland\Services\HpsCreditService;
+
 require_once("setup.php");
 
 class VisaTests extends PHPUnit_Framework_TestCase


### PR DESCRIPTION
Implimented namespacing throughout library because class names were too generic to exist without namespaces.

Most unit tests passed. Those that didn't are likely because of lack of valid API credentials.